### PR TITLE
fix: do not preconnect to database

### DIFF
--- a/src/lib/server/prisma.ts
+++ b/src/lib/server/prisma.ts
@@ -1,5 +1,4 @@
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
-await prisma.$connect();
 export default prisma;


### PR DESCRIPTION
By not preconnecting to the database, we are ensuring connections are only made when the prisma object is used.

This also fixes the fact that a DATABASE_URL needs to be provided at build-time.

This was merged upstream in https://github.com/ttoino/ementas/pull/3, but we can't sync the fork because recent commits are not considered stable for deployment.

Therefore, we need to merge it individually.
